### PR TITLE
Implement time out in check_server

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: easyclimate
 Title: Easy Access to High-Resolution Daily Climate Data for Europe
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: c(
     person("Verónica", "Cruz-Alonso", , "veronica.cral@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0642-036X")),
@@ -26,6 +26,7 @@ BugReports: https://github.com/VeruGHub/easyclimate/issues
 Depends: 
     R (>= 3.5.0)
 Imports:
+    R.utils,
     RCurl,
     stats,
     terra (>= 1.2-13)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# easyclimate 0.1.11
+
+* Improved check_server diagnosis. Now timing out after 30 seconds, and providing better error messages.
+
 # easyclimate 0.1.10
 
 * Improved check_server diagnosis.

--- a/R/Globals.R
+++ b/R/Globals.R
@@ -1,0 +1,1 @@
+utils::globalVariables(c("lon", "lat"))

--- a/R/get_daily_climate_single.R
+++ b/R/get_daily_climate_single.R
@@ -40,7 +40,7 @@
 #' # Coords as matrix
 #' coords <- matrix(c(-5.36, 37.40), ncol = 2)
 #' ex <- get_daily_climate_single(coords, period = "2001-01-01")  # single day
-#' ex <- get_daily_climate_single(coords, period = c("2001-01-01", "2001-01-03"))  # 1st AND 3rd Jan 2001
+#' ex <- get_daily_climate_single(coords, period = c("2001-01-01", "2001-01-03")) #1st & 3rd Jan 2001
 #' ex <- get_daily_climate_single(coords, period = "2001-01-01:2001-01-03")  # 1st TO 3rd Jan 2001
 #' ex <- get_daily_climate_single(coords, period = 2008)  # entire year
 #' ex <- get_daily_climate_single(coords, period = c(2008, 2010))  # 2008 AND 2010

--- a/man/get_daily_climate_single.Rd
+++ b/man/get_daily_climate_single.Rd
@@ -47,7 +47,7 @@ library(easyclimate)
 # Coords as matrix
 coords <- matrix(c(-5.36, 37.40), ncol = 2)
 ex <- get_daily_climate_single(coords, period = "2001-01-01")  # single day
-ex <- get_daily_climate_single(coords, period = c("2001-01-01", "2001-01-03"))  # 1st AND 3rd Jan 2001
+ex <- get_daily_climate_single(coords, period = c("2001-01-01", "2001-01-03")) #1st & 3rd Jan 2001
 ex <- get_daily_climate_single(coords, period = "2001-01-01:2001-01-03")  # 1st TO 3rd Jan 2001
 ex <- get_daily_climate_single(coords, period = 2008)  # entire year
 ex <- get_daily_climate_single(coords, period = c(2008, 2010))  # 2008 AND 2010

--- a/tests/testthat/test-build_url.R
+++ b/tests/testthat/test-build_url.R
@@ -12,8 +12,10 @@ test_that("built url is correct", {
                    "ftp://palantir.boku.ac.at/Public/ClimateData/v3_cogeo/AllDataRasters/tmin/DownscaledTmin2008_cogeo.tif")
 })
 
-test_that("server is running and built url exists", {
-  skip_on_cran()
-  skip_on_ci()
-  expect_true(check_server())
-})
+
+# Better to check server status differently than giving package error if server not working
+# test_that("server is running and built url exists", {
+#   skip_on_cran()
+#   skip_on_ci()
+#   expect_true(check_server())
+# })

--- a/tests/testthat/test-get_daily_climate.R
+++ b/tests/testthat/test-get_daily_climate.R
@@ -5,7 +5,7 @@ test_that("downloading several variables gives expected results", {
 
   skip_on_cran()
   skip_on_ci()
-  skip_if_not(check_server())
+  skip_if_not(suppressWarnings(check_server(verbose = FALSE)))
 
   ## Input matrix
   coords.mat <- matrix(c(-5.36, 37.40, -5.5, 37.5), ncol = 2, byrow = TRUE)

--- a/tests/testthat/test-get_daily_climate_single.R
+++ b/tests/testthat/test-get_daily_climate_single.R
@@ -58,7 +58,7 @@ test_that("different climatic_var_single give expected results", {
 
   skip_on_cran()
   skip_on_ci()
-  skip_if_not(check_server())
+  skip_if_not(suppressWarnings(check_server(verbose = FALSE)))
 
   ## Input matrix
   coords.mat <- matrix(c(-5.36, 37.40, -4.05, 38.10), ncol = 2, byrow = TRUE)
@@ -106,7 +106,7 @@ test_that("different input formats (points) give expected results", {
 
   skip_on_cran()
   skip_on_ci()
-  skip_if_not(check_server())
+  skip_if_not(suppressWarnings(check_server(verbose = FALSE)))
 
   ## Input matrix (tested above)
   coords.mat <- matrix(c(-5.36, 37.40, -4.05, 38.10), ncol = 2, byrow = TRUE)
@@ -148,7 +148,7 @@ test_that("polygon input give expected results", {
 
   skip_on_cran()
   skip_on_ci()
-  skip_if_not(check_server())
+  skip_if_not(suppressWarnings(check_server(verbose = FALSE)))
 
   coords <- terra::vect("POLYGON ((-5 38, -5 37.95, -4.95 37.95, -4.95 38, -5 38))")
 
@@ -182,7 +182,7 @@ test_that("output raster is correct", {
 
   skip_on_cran()
   skip_on_ci()
-  skip_if_not(check_server())
+  skip_if_not(suppressWarnings(check_server(verbose = FALSE)))
 
   library(terra)
 
@@ -208,7 +208,7 @@ test_that("different period formats give expected results", {
 
   skip_on_cran()
   skip_on_ci()
-  skip_if_not(check_server())
+  skip_if_not(suppressWarnings(check_server(verbose = FALSE)))
 
   coords <- matrix(c(-5.36, 37.40, -4.05, 38.10), ncol = 2, byrow = TRUE)
 


### PR DESCRIPTION
check_server() sometimes keeps running for minutes, waiting for a response from the server. I've implemented a time out mechanism so check_server will stop trying after 30 seconds. This requires adding another dependency (R.utils) but that does not increase dependency load (see https://cran.r-project.org/web/packages/R.utils/index.html).

I've also fixed a couple minor things raised by RCMD-check, and improved tests to avoid warnings